### PR TITLE
Adição de Endpoint Simples juntamente de Testes Unitários 

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /api/
 COPY . /api/
 
 
-RUN mvn clean package -DskipTests
+RUN mvn clean package
 
 
 EXPOSE 8082

--- a/api/src/main/java/com/o2tapi/api/HelloController.java
+++ b/api/src/main/java/com/o2tapi/api/HelloController.java
@@ -1,0 +1,32 @@
+package com.o2tapi.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller that handles HTTP requests to demonstrate basic functionalities and error handling.
+ */
+@RestController
+public class HelloController {
+    
+    /**
+     * Simple endpoint to return a greeting message.
+     * 
+     * @return A static greeting message "Hello, O2t Backend!".
+     */
+    @GetMapping("/hello")
+    public String sayHello() {
+        return "Hello, O2t Backend!";
+    }
+
+    /**
+     * Endpoint to demonstrate error handling by intentionally throwing a runtime exception.
+     *
+     * @return Nothing, as it always throws an exception.
+     * @throws RuntimeException always thrown to simulate an error scenario.
+     */
+    @GetMapping("/hello-error")
+    public String throwError() {
+        throw new RuntimeException("Intentional error for testing purposes");
+    }
+}

--- a/api/src/main/java/com/o2tapi/api/exceptions/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/o2tapi/api/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.o2tapi.api.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Global exception handler for the application.
+ * This class provides a central place to handle all unexpected exceptions that occur within the application.
+ * It captures exceptions and translates them into user-friendly messages, while also logging the details
+ * for debugging purposes.
+ */
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * Handles generic exceptions thrown by any method in the application.
+     * This handler ensures that no exception goes uncaught, thereby preventing any unhandled exceptions
+     * from causing the application to crash.
+     *
+     * @param e The exception that was caught.
+     * @return A user-friendly message indicating an error has occurred, alongside the exception's own message.
+     * @throws Exception Indicates that this method itself might rethrow any unexpected exceptions.
+     */
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public String handleException(Exception e) {
+        // Log the exception details here or perform other error handling
+        return "Error occurred: " + e.getMessage();
+    }
+}

--- a/api/src/test/java/com/o2tapi/api/ApiApplicationTests.java
+++ b/api/src/test/java/com/o2tapi/api/ApiApplicationTests.java
@@ -1,12 +1,51 @@
 package com.o2tapi.api;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 class ApiApplicationTests {
 
+	@Autowired
+    private MockMvc mockMvc;
+
+    /**
+     * Tests if the Spring context loads properly indicating all necessary components are correctly configured.
+     */
 	@Test
 	void contextLoads() {
 	}
+
+    /**
+     * Verifies that the '/hello' endpoint returns the correct message.
+     * This test ensures that the endpoint not only responds with a status code of 200 (OK),
+     * but also confirms that the response body contains the expected text.
+     *
+     * @throws Exception if the perform method fails
+     */
+	@Test
+    void testHelloEndpoint() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/hello"))
+               .andExpect(MockMvcResultMatchers.status().isOk())
+               .andExpect(MockMvcResultMatchers.content().string("Hello, O2t Backend!"));
+    }
+
+    /**
+     * Tests the '/hello-error' endpoint to ensure it handles errors as expected by returning an internal server error.
+     * This test checks if the application correctly identifies and handles the thrown exception by returning
+     * a 500 Internal Server Error status.
+     *
+     * @throws Exception if the perform method fails
+     */
+    @Test
+    void testHelloEndpointErrorScenario() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/hello-error"))
+               .andExpect(MockMvcResultMatchers.status().isInternalServerError());
+    }
 }


### PR DESCRIPTION
Closes #2 
Adição dos seguintes endpoints:
- `/hello`: endpoint de método `get` com retorno simples de String
- `/hello-error`: endpoint que levanta uma exceção para captura de teste unitário